### PR TITLE
Update link to spec doc in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A TypeScript implementation of the Hobbits Ethereum Wire Protocol.
 
 ## Overview
-The goal of hobbits is to define a lightweight wire protocol for ETH2.0 in order to facilitate rapid prototyping and cross-client communication. Read the [specification](https://github.com/Whiteblock/hobbits) for more information.
+The goal of hobbits is to define a lightweight wire protocol for ETH2.0 in order to facilitate rapid prototyping and cross-client communication. Read the [specification](https://github.com/deltap2p/hobbits/blob/master/specs/spec.md) for more information.
 
 ## Install Instructions
 


### PR DESCRIPTION
Whiteblock say that the spec repo is now owned by DeltaP2P.  

[Reference](https://github.com/whiteblock/hobbits/blob/master/README.md)