### PR TITLE
Abstract Server Port in Unit Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A TypeScript implementation of the Hobbits Ethereum Wire Protocol.
 
 ## Overview
-The goal of hobbits is to define a lightweight wire protocol for ETH2.0 in order to facilitate rapid prototyping and cross-client communication. Read the [specification](https://github.com/Whiteblock/hobbits) for more information.
+The goal of hobbits is to define a lightweight wire protocol for ETH2.0 in order to facilitate rapid prototyping and cross-client communication. Read the [specification](https://github.com/deltap2p/hobbits/blob/master/specs/spec.md) for more information.
 
 ## Install Instructions
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,7 +1,9 @@
-import {assert} from "chai";
+import { assert } from "chai";
 import net from "net";
-import HobbitsP2PNetwork, {HobbitsOpts} from "../src";
-import {delayedConnection} from "./helpers";
+import HobbitsP2PNetwork, { HobbitsOpts } from "../src";
+import { delayedConnection } from "./helpers";
+
+const defaultPeerPort = 9000
 
 describe("Server", () => {
   const ctx: HobbitsOpts = {
@@ -13,7 +15,7 @@ describe("Server", () => {
       latestFinalizedSlot: 1
     }
   };
-  // const server2 = new HobbitsP2PNetwork({...ctx, port: 9001, bootnodes: ["127.0.0.1:9000"]});
+  // const server2 = new HobbitsP2PNetwork({...ctx, port: 9001, bootnodes: [`127.0.0.1:${defaultPeerPort}`]});
 
   describe("Startup/Shutdown", async () => {
     const server = new HobbitsP2PNetwork(ctx);
@@ -52,7 +54,7 @@ describe("Server", () => {
     // Check total connections after the before script runs
     it("It should have 1 connection", async () => {
       // Make a connection
-      await delayedConnection(9000);
+      await delayedConnection(defaultPeerPort);
 
       // Check peers
       const peersAfter: number = server.getTotalPeers();


### PR DESCRIPTION
To prevent headaches in case the default port is changed in the future. This'll make it easier to reflect those changes in the tests.